### PR TITLE
Fixing view hierarchy inconstancies crash

### DIFF
--- a/Example/Extra.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/Extra.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Extra/Classes/UIKit/UIViewController+Extra.swift
+++ b/Extra/Classes/UIKit/UIViewController+Extra.swift
@@ -68,9 +68,9 @@ extension Extra where Base: UIViewController {
     insets: UIEdgeInsets = .zero) {
     
     if let childView = childController.view {
-      self.base.addChildViewController(childController)
       childView.frame = container.bounds
       container.ex.addSubview(childView, insets: insets)
+      self.base.addChildViewController(childController)
       childController.didMove(toParentViewController: self.base)
     } else {
       fatalError("Your view controller \(childController) does not contain any view")


### PR DESCRIPTION
When using the `vcC.ex.addChildViewController(vcA)` function while `vcA`'s view was part of a `vcB`'s view hierarchy (but where `vcA` was not a child of `vcB`), the app would crash with the following error: ```*** Terminating app due to uncaught exception 'UIViewControllerHierarchyInconsistency', reason: 'child view controller:<vcA> should have parent view controller:<vcB> but requested parent is:<vcC>'```

Adding `vcA`'s view to `vcC`'s viewHierarchy before adding `vcA` as child of `vcC` prevents the issue.